### PR TITLE
Updated to use the arcball instead of orbit control

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -1,5 +1,6 @@
 import * as THREE from 'https://cdn.skypack.dev/three@0.133.0/build/three.module.js'
 import { OrbitControls } from 'https://cdn.skypack.dev/three@0.133.0/examples/jsm/controls/OrbitControls.js';
+import { ArcballControls } from 'https://cdn.skypack.dev/three@0.133.0/examples/jsm/controls/ArcballControls.js';
 import { GLTFLoader } from 'https://cdn.skypack.dev/three@0.133.0/examples/jsm/loaders/GLTFLoader.js';
 
 window.model = {
@@ -73,7 +74,8 @@ function initialize3D() {
     renderer.setSize(div.clientWidth, div.clientHeight);
     div.appendChild(renderer.domElement);
 
-    const controls = new OrbitControls(camera, renderer.domElement);
+    const controls = new ArcballControls(camera, renderer.domElement,scene);
+    controls.setGizmosVisible(false);
 
     const directionalLight = new THREE.DirectionalLight(0xffffff, 1.0);
     directionalLight.position.set(0.5, 0.5, 0);


### PR DESCRIPTION
A very minimal (two lines) change to use the newer arcball control of threejs  instead of the traditional orbit control 
Arcball are more appropriate when you need free inspection of generic 3d shapes. WRT to the traditional orbit it has no dominant axis it has a very convenient double click focusing operation and works perfectly on touch based interfaces (pinch works as expected) 

https://threejs.org/examples/?q=arc#misc_controls_arcball

Great project BTW!
